### PR TITLE
Remove player from match when player leaves

### DIFF
--- a/app/src/main/java/com/cascadia/hidenseek/Active.java
+++ b/app/src/main/java/com/cascadia/hidenseek/Active.java
@@ -2,7 +2,6 @@ package com.cascadia.hidenseek;
 
 import android.Manifest;
 import android.annotation.TargetApi;
-import android.app.ActionBar;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
@@ -30,6 +29,7 @@ import android.widget.Toast;
 
 import com.cascadia.hidenseek.Player.Role;
 import com.cascadia.hidenseek.Player.Status;
+import com.cascadia.hidenseek.network.DeletePlayerRequest;
 import com.cascadia.hidenseek.network.DeletePlayingRequest;
 import com.cascadia.hidenseek.network.PlayerListFragment;
 import com.cascadia.hidenseek.network.PutGpsRequest;
@@ -51,9 +51,6 @@ import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.MarkerOptions;
 
 import java.util.ArrayList;
-import java.util.Calendar;
-
-import com.cascadia.hidenseek.Timer;
 
 public class Active extends FragmentActivity implements OnMapReadyCallback,
         ConnectionCallbacks, OnConnectionFailedListener, LocationListener, PlayerListFragment.OnListFragmentInteractionListener {
@@ -123,6 +120,14 @@ public class Active extends FragmentActivity implements OnMapReadyCallback,
         ImageButton btnLeave = (ImageButton) findViewById(R.id.btnLeaveGame);
         btnLeave.setOnClickListener(new View.OnClickListener() {
             public void onClick(View v) {
+                // send a message to the API that the player is leaving, but don't worry if it works
+                DeletePlayerRequest deletePlayerRequest = new DeletePlayerRequest() {
+                    @Override
+                    protected void onComplete(Player player) {}
+                    @Override
+                    protected void onException(Exception e) { }
+                };
+                deletePlayerRequest.doRequest(player);
                 Intent intent = new Intent(Active.this, Home.class);
                 startActivity(intent);
             }

--- a/app/src/main/java/com/cascadia/hidenseek/HostConfig.java
+++ b/app/src/main/java/com/cascadia/hidenseek/HostConfig.java
@@ -20,6 +20,7 @@ import android.widget.Toast;
 
 import com.cascadia.hidenseek.Match.MatchType;
 import com.cascadia.hidenseek.Match.Status;
+import com.cascadia.hidenseek.network.DeletePlayerRequest;
 import com.cascadia.hidenseek.network.GetMatchRequest;
 import com.cascadia.hidenseek.network.GetPlayerListRequest;
 import com.cascadia.hidenseek.network.PutStartRequest;
@@ -52,9 +53,6 @@ public class HostConfig extends Activity {
             d.show();
             finish();
         }
-//		int temp=LoginManager.playerMe.getId();
-//		Toast.makeText(this, Integer.toString(temp), Toast.LENGTH_LONG).show();
-//		LoginManager.playerMe.setID(temp);
         Toast.makeText(this, "Id Changed to" + Integer.toString(LoginManager.playerMe.getId()), Toast.LENGTH_LONG).show();
         initSettings();
 
@@ -261,6 +259,14 @@ public class HostConfig extends Activity {
                 .setPositiveButton("Yes",
                         new DialogInterface.OnClickListener() {
                             public void onClick(DialogInterface dialog, int id) {
+
+                                DeletePlayerRequest deletePlayerRequest = new DeletePlayerRequest() {
+                                    @Override
+                                    protected void onComplete(Player player) {}
+                                    @Override
+                                    protected void onException(Exception e) { }
+                                };
+                                deletePlayerRequest.doRequest(LoginManager.playerMe);
                                 finish();
                             }
                         })

--- a/app/src/main/java/com/cascadia/hidenseek/network/DeletePlayerRequest.java
+++ b/app/src/main/java/com/cascadia/hidenseek/network/DeletePlayerRequest.java
@@ -1,0 +1,32 @@
+package com.cascadia.hidenseek.network;
+
+import com.cascadia.hidenseek.Player;
+
+/**
+ * Created by deb on 12/12/16.
+ * Send the API message to delete the player from the match
+ */
+
+public abstract class DeletePlayerRequest extends NetworkRequest {
+
+    public void doRequest(Player toPost) {
+        player = toPost;
+        Request request = new Request();
+        request.url = baseUrl + "matches/" + toPost.getAssociatedMatch().getId() + "/players/" + toPost.getId();
+        request.type = NetworkBase.RequestType.DELETE;
+        doRequest(request);
+    }
+
+    //To be overwritten
+    protected abstract void onComplete(Player player);
+
+    @Override
+    protected final void processPostExecute(String s) {
+        if (!player.processPostResponse(s)) {
+            player.setID(0);
+        }
+        onComplete(player);
+    }
+
+    private Player player;
+}

--- a/app/src/main/java/com/cascadia/hidenseek/network/NetworkBase.java
+++ b/app/src/main/java/com/cascadia/hidenseek/network/NetworkBase.java
@@ -9,147 +9,165 @@ import java.util.Scanner;
 
 public class NetworkBase {
 
-	public NetworkBase() {
-	}
-	
-	public enum RequestType {
-		GET,
-		PUT,
-		PUT_NoArgs,
-		POST,
-		DELETE
-	}
-	
-	public String Request(Request r) throws IOException {
-		switch(r.type) {
-		case GET:
-			return Get(r.url);
-		case POST:
-			return Post(r.url, r.jsonArgs);
-		case PUT:
-			return Put(r.url, r.jsonArgs);
-		case PUT_NoArgs:
-			return Put(r.url);
-		default:
-			return null; //suppress errors
-		}
-	}
-	
-	//Sends a PUT request with a text body to the given url and returns
-	//the received text
-	public String Put(String url, String jsonArgs) throws IOException {
-		return post(url, jsonArgs, true);
-	}
-	
+    public NetworkBase() {
+    }
 
-	
-	//Sends a POST request with a text body to the given url and returns
-	//the received text
-	public String Post(String url, String jsonArgs) throws IOException {
-		return post(url, jsonArgs, false);
-	}
-	
-	
-	//Sends a request to the given strUrl with the given jsonArgs as text body
-	//and returns the returned text info.
-	//Sends the message as a POST request unless isPut is set to true, in
-	//which case the message is sent as a PUT request.	
-	private String post(String strUrl, String jsonArgs, boolean isPut)
-			throws IOException {
-		URL url;
-		String toReturn = "";
-		try {
-			url = new URL(strUrl);
-		} catch (MalformedURLException e1) {
-			e1.printStackTrace();
-			return "";
-		}
-		connection = (HttpURLConnection) url.openConnection();
-		try {
-			connection.setDoOutput(true);
-			//The above automatically sets the request method to "POST";
-			//change it to "PUT" if requested.
-			if(isPut) {
-				connection.setRequestMethod("PUT");
-			}
-			//Sets connection to stream in chunks; 0 means use system default
-			connection.setChunkedStreamingMode(0);
-			writeOutStream(jsonArgs);
-			toReturn = getInStream();
-		} catch (RuntimeException e) {
-			e.printStackTrace();
-		} finally {
-			connection.disconnect();
-		}
-		return toReturn;
-	}
-	/**
-	 * Sends an empty GET request to the given {@code url}
-	 * @param url Address to send the request to.
-	 * @return The body of the HTTP response as a string
-	 * @throws IOException in case of network error
-	 */
-	public String Get(String url) throws IOException {
-		return get(url, false);
-	}
-	
-	/**
-	 * Sends an empty PUT request to the given {@code url}
-	 * @param url Address to send the request to.
-	 * @return The body of the HTTP response as a string
-	 * @throws IOException in case of network error
-	 */
-	public String Put(String url) throws IOException {
-		return get(url, true);
-	}
-	
-	//Sends a request to the given strUrl and returns the returned text info.
-	//Sends the message as a GET request unless isPut is set to true, in
-	//which case the message is sent as a PUT request.
-	private String get(String strUrl, boolean isPut) throws IOException {
-		URL url;
-		String toReturn;
-		try {
-			url = new URL(strUrl);
-		} catch (MalformedURLException e1) {
-			e1.printStackTrace();
-			return "";
-		}
-		connection = (HttpURLConnection) url.openConnection();
-		try {
-			//Automatically set to "GET"; change it to "PUT" if requested.
-			if(isPut) {
-				connection.setRequestMethod("PUT");
-			}
-			toReturn = getInStream();
-		} finally {
-			connection.disconnect();
-		}
-		return toReturn;
-	}
+    public enum RequestType {
+        GET,
+        PUT,
+        PUT_NoArgs,
+        POST,
+        DELETE;
 
-	//Assumes that this.connection is open and attempts to write the given
-	//output to it
-	private void writeOutStream(String output) throws IOException {
-		connection.getOutputStream().write(output.getBytes());
-	}
-	
-	//Assumes that this.connection is open and attempts to read a stream from it
-	private String getInStream() throws IOException {
-		String toReturn = convertStreamToString(connection.getInputStream());
-		return toReturn;
-	}
-	
-	//Method from http://stackoverflow.com/questions
-	//					/309424/read-convert-an-inputstream-to-a-string
-	//Gets a string from an input stream
-	private String convertStreamToString(InputStream istream) {
-	    Scanner s = new Scanner(istream).useDelimiter("\\A");
-	    String toReturn = s.hasNext() ? s.next() : "";
-	    s.close();
-	    return toReturn;
-	}
-	
-	private HttpURLConnection connection;
+        public String toString() {
+            switch (this) {
+                case GET:
+                    return "GET";
+                case PUT:
+                case PUT_NoArgs:
+                    return "PUT";
+                case POST:
+                    return "POST";
+                default:
+                    return "DELETE";
+            }
+        }
+    }
+
+    public String Request(Request r) throws IOException {
+        switch (r.type) {
+            case GET:
+                return Get(r.url);
+            case POST:
+                return Post(r.url, r.jsonArgs);
+            case PUT:
+                return Put(r.url, r.jsonArgs);
+            case PUT_NoArgs:
+                return Put(r.url);
+            case DELETE:
+                return send(r.url, r.type);
+            default:
+                return null; //suppress errors
+        }
+    }
+
+    //Sends a PUT request with a text body to the given url and returns
+    //the received text
+    public String Put(String url, String jsonArgs) throws IOException {
+        return post(url, jsonArgs, true);
+    }
+
+
+    //Sends a POST request with a text body to the given url and returns
+    //the received text
+    public String Post(String url, String jsonArgs) throws IOException {
+        return post(url, jsonArgs, false);
+    }
+
+
+    //Sends a request to the given strUrl with the given jsonArgs as text body
+    //and returns the returned text info.
+    //Sends the message as a POST request unless isPut is set to true, in
+    //which case the message is sent as a PUT request.
+    private String post(String strUrl, String jsonArgs, boolean isPut)
+            throws IOException {
+        URL url;
+        String toReturn = "";
+        try {
+            url = new URL(strUrl);
+        } catch (MalformedURLException e1) {
+            e1.printStackTrace();
+            return "";
+        }
+        connection = (HttpURLConnection) url.openConnection();
+        try {
+            connection.setDoOutput(true);
+            //The above automatically sets the request method to "POST";
+            //change it to "PUT" if requested.
+            if (isPut) {
+                connection.setRequestMethod("PUT");
+            }
+            //Sets connection to stream in chunks; 0 means use system default
+            connection.setChunkedStreamingMode(0);
+            writeOutStream(jsonArgs);
+            toReturn = getInStream();
+        } catch (RuntimeException e) {
+            e.printStackTrace();
+        } finally {
+            connection.disconnect();
+        }
+        return toReturn;
+    }
+
+    /**
+     * Sends an empty GET request to the given {@code url}
+     *
+     * @param url Address to send the request to.
+     * @return The body of the HTTP response as a string
+     * @throws IOException in case of network error
+     */
+    public String Get(String url) throws IOException {
+        return send(url, RequestType.GET);
+    }
+
+    /**
+     * Sends an empty PUT request to the given {@code url}
+     *
+     * @param url Address to send the request to.
+     * @return The body of the HTTP response as a string
+     * @throws IOException in case of network error
+     */
+    public String Put(String url) throws IOException {
+        return send(url, RequestType.PUT);
+    }
+
+    //Sends a request to the given strUrl and returns the returned text info.
+    //Sends the message as a GET request unless requestType is not GET, in
+    //which case the message is sent as the appropriate request.
+    private String send(String strUrl, RequestType requestType) throws IOException {
+        URL url;
+        String toReturn;
+        try {
+            url = new URL(strUrl);
+        } catch (MalformedURLException e1) {
+            e1.printStackTrace();
+            return "";
+        }
+        connection = (HttpURLConnection) url.openConnection();
+        try {
+            //Automatically set to "GET"; change it to "PUT" if requested.
+            if (requestType != RequestType.GET) {
+                connection.setRequestMethod(requestType.toString());
+            }
+            toReturn = getInStream();
+        } finally {
+            connection.disconnect();
+        }
+        return toReturn;
+    }
+
+    //Assumes that this.connection is open and attempts to write the given
+    //output to it
+    private void writeOutStream(String output) throws IOException {
+        connection.getOutputStream().write(output.getBytes());
+    }
+
+    //Assumes that this.connection is open and attempts to read a stream from it
+    private String getInStream() throws IOException {
+        String toReturn = convertStreamToString(connection.getInputStream());
+        return toReturn;
+    }
+
+    //Method from http://stackoverflow.com/questions
+    //					/309424/read-convert-an-inputstream-to-a-string
+    //Gets a string from an input stream
+    private String convertStreamToString(InputStream istream) {
+        Scanner s = new Scanner(istream).useDelimiter("\\A");
+        String toReturn = s.hasNext() ? s.next() : "";
+        s.close();
+        return toReturn;
+    }
+
+    private HttpURLConnection connection;
 
 }


### PR DESCRIPTION
Added DeletePlayerRequest class and modified NetworkBase to handle DELETE messages.  If the Seeker cancels the match, he/she is removed from the match, but the match is not deleted.  We need to handle the situation where a match has been defined, one or more players join, and the Seeker cancels it.  But this change handles the case of a player leaving the match while it is pending or after it has started.

Fixes #7.